### PR TITLE
fix: client.set_token token type

### DIFF
--- a/clickup/client.py
+++ b/clickup/client.py
@@ -79,10 +79,10 @@ class Client(object):
         # response = self._parse(requests.request(method, url, headers=_headers, **kwargs))
         return response
 
-    def set_token(self, token: dict) -> None:
-        """Sets the User token for its use in this library.
+    def set_token(self, token: str) -> None:
+        """Sets the access_token for its use in this library.
         Args:
-            token (dict): User token data.
+            token (str): access_token data.
         """
         self.token = token
 


### PR DESCRIPTION
# Description

`self.token` is not used as a dict, but as an `access_token` string:
https://github.com/GearPlug/clickup-python/blob/be3fdbdbc55a51fe43f63fe5fce71e585501324e/clickup/client.py#L609-L614